### PR TITLE
Fix missing import for Throwable

### DIFF
--- a/Exception/JsonExceptionRender.php
+++ b/Exception/JsonExceptionRender.php
@@ -1,10 +1,10 @@
 <?php
 namespace Ipaas\Gapp\Exception;
 
-use Exception;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Http\Response;
 use Ipaas\Gapp\Response as GappResponse;
+use Throwable;
 
 class JsonExceptionRender
 {


### PR DESCRIPTION
Hi, I've found some bug in current 4.0.1 version, where exception handler was causing another exception because of the wrong parameter type (actually just missing import for Throwable). I suggest to merge this to master and create appropriate v4.0.2 tag, because it's the only place where this may occur.