### PR TITLE
Fix throw request exception issue

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -117,7 +117,7 @@ class Request extends BaseRequest
         $validator = Validator::make($list, $rules);
 
         if ($validator->fails()) {
-            throw new ValidationException($validator, 'Invalid request', Response::HTTP_UNPROCESSABLE_ENTITY);
+            throw new ValidationException($validator, new Response('Invalid request', Response::HTTP_UNPROCESSABLE_ENTITY));
         }
 
         return $this;


### PR DESCRIPTION
This commit fix exception where status code 500 was thrown instead of code 422. It was happening when request didn't required json response content type.

Reason:
Laravel requires response object to be passed to constructor instead of string.